### PR TITLE
opa CVE-2025-46569 fixed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/dop251/goja v0.0.0-20250309171923-bcd7cc6bf64c
 	github.com/ghodss/yaml v1.0.0
 	github.com/glebarez/go-sqlite v1.22.0
-	github.com/open-policy-agent/opa v0.62.1
+	github.com/open-policy-agent/opa v1.4.2
 	github.com/radovskyb/watcher v1.0.7
 	github.com/sirupsen/logrus v1.9.3
 	github.com/spf13/cobra v1.8.0


### PR DESCRIPTION
`"VulnerabilityID": "CVE-2025-46569",
  "PkgID": "github.com/open-policy-agent/opa@v0.62.1",
  "PkgName": "github.com/open-policy-agent/opa",
  "PkgIdentifier": {
       "PURL": "pkg:golang/github.com/open-policy-agent/opa@v0.62.1",
        "UID": "c040e33a7a0de142"
  },
  "InstalledVersion": "v0.62.1",
  "FixedVersion": "1.4.0",
  "Status": "fixed",`