### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   release:


### PR DESCRIPTION
Potential fix for [https://github.com/mxlint/mxlint-cli/security/code-scanning/1](https://github.com/mxlint/mxlint-cli/security/code-scanning/1)

To fix the problem, we should add a `permissions` block to the workflow file `.github/workflows/release.yml`. This block can be added at the top level (applies to all jobs) or at the job level (applies only to the specific job). Since the workflow only has one job, either location is acceptable, but top-level is preferred for clarity and future extensibility. The minimal starting point is `contents: read`, but since the workflow uses a release action, it may need `contents: write` to create or update releases and upload assets. Therefore, set `contents: write` at the workflow level. No other permissions are required unless the workflow interacts with issues or pull requests, which it does not.

**Required changes:**
- Add a `permissions` block at the top level of `.github/workflows/release.yml` (after `name:` and before `on:`).
- Set `contents: write` as the value.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
