### PR TITLE
fix: string values starting with \n exported as invalid YAML literal block

### DIFF
--- a/mpr/mpr.go
+++ b/mpr/mpr.go
@@ -795,6 +795,10 @@ func normalizeMultilineValue(v interface{}) interface{} {
 	case string:
 		normalized := normalizeMultilineString(value)
 		if strings.Contains(normalized, "\n") {
+			normalized = strings.TrimLeft(normalized, "\n")
+			if !strings.Contains(normalized, "\n") {
+				return normalized
+			}
 			if startsWithWhitespace(normalized) {
 				return doubleQuotedMultilineString(normalized)
 			}


### PR DESCRIPTION
String fields whose value starts with a newline (e.g. expression values) were exported with a |4 literal block indicator, producing invalid YAML that caused the linter to crash with Error parsing YAML file.

Root cause: after indent-stripping, the leading \n was still present, triggering the multiline code path even when the actual content is a single line. The fix trims leading newlines before the multiline check so these values are exported as plain scalars.